### PR TITLE
Set up service account with appropriate permissions for new benchmarks

### DIFF
--- a/manifests/gmp-operator/2_operator.yaml
+++ b/manifests/gmp-operator/2_operator.yaml
@@ -41,6 +41,8 @@ kind: ServiceAccount
 metadata:
   name: operator
   namespace: gmp-system
+  annotations:
+    iam.gke.io/gcp-service-account: gmp-prombench@{{ .Env.PROJECT_ID }}.iam.gserviceaccount.com
 ---
 # Source: prometheus-engine/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/scenarios/gmp-agent/1_collector.yaml
+++ b/manifests/scenarios/gmp-agent/1_collector.yaml
@@ -120,8 +120,7 @@ spec:
             - all
           privileged: false
       - name: prometheus
-        # v2.45.3-gmp.8-rc.0
-        image: gke.gcr.io/prometheus-engine/prometheus:sha256:3e6493d4b01ab583382731491d980bc164873ad4969e92c0bdd0da278359ccac
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.7-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage

--- a/manifests/scenarios/gmp-noexport/1_collector.yaml
+++ b/manifests/scenarios/gmp-noexport/1_collector.yaml
@@ -120,8 +120,7 @@ spec:
             - all
           privileged: false
       - name: prometheus
-        # v2.45.3-gmp.8-rc.0
-        image: gke.gcr.io/prometheus-engine/prometheus:sha256:3e6493d4b01ab583382731491d980bc164873ad4969e92c0bdd0da278359ccac
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.7-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage

--- a/manifests/scenarios/gmp/1_collector.yaml
+++ b/manifests/scenarios/gmp/1_collector.yaml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   name: collector
   namespace: gmp-system
+  annotations:
+    iam.gke.io/gcp-service-account: gmp-prombench@{{ .Env.PROJECT_ID }}.iam.gserviceaccount.com
 ---
 # Source: prometheus-engine/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -120,8 +122,7 @@ spec:
             - all
           privileged: false
       - name: prometheus
-        # v2.45.3-gmp.8-rc.0
-        image: gke.gcr.io/prometheus-engine/prometheus:sha256:3e6493d4b01ab583382731491d980bc164873ad4969e92c0bdd0da278359ccac
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.7-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage

--- a/scripts/bench-start.sh
+++ b/scripts/bench-start.sh
@@ -7,7 +7,7 @@ IFS=$'\t\n'
 . ./scripts/util.sh
 
 ZONE="us-central1-a"
-PROJECT_ID=$(gcloud config get project)
+export PROJECT_ID=$(gcloud config get project)
 
 BENCH_NAME=$1
 if [ -z "${BENCH_NAME}" ]; then
@@ -50,6 +50,6 @@ echo "## Applying scenario resources"
 
 # TODO(bwplotka): All scenarios has the same load and requires GMP operator. Make it more flexible
 # if needed later on.
-#kubectlExpandApply "./manifests/gmp-operator"
+kubectlExpandApply "./manifests/gmp-operator"
 kubectlExpandApply "./manifests/load/avalanche.yaml"
 kubectlExpandApply "${SCENARIO}"

--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -47,6 +47,46 @@ fi
 trap "exit 1"           HUP INT PIPE QUIT TERM
 trap 'rm -r "$TEMP_DIR"'  EXIT
 
+# Make sure the gmp-prombench Service Account exists
+SA="gmp-prombench"
+if ! gcloud iam service-accounts list --project=${PROJECT_ID} | grep ${SA}
+then
+  gcloud iam service-accounts create "${SA}" --project=${PROJECT_ID} \
+  --description="A service account just to used for the core GMP manifests" \
+  --display-name="GMP Prombench Service Account" \
+  --quiet
+fi
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SA}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountUser" \
+  --quiet
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SA}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/monitoring.metricWriter" \
+  --quiet
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SA}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/monitoring.metricWriter" \
+  --quiet
+
+gcloud iam service-accounts add-iam-policy-binding ${SA}@${PROJECT_ID}.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:${PROJECT_ID}.svc.id.goog[core/prometheus]" \
+    --project ${PROJECT_ID}
+
+gcloud iam service-accounts add-iam-policy-binding ${SA}@${PROJECT_ID}.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:${PROJECT_ID}.svc.id.goog[gmp-system/operator]" \
+    --project ${PROJECT_ID}
+
+gcloud iam service-accounts add-iam-policy-binding ${SA}@${PROJECT_ID}.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:${PROJECT_ID}.svc.id.goog[gmp-system/collector]" \
+    --project ${PROJECT_ID}
+
 echo "## Installing core resources"
 PROJECT_ID=${PROJECT_ID} ${GOMPLATE} --input-dir=./manifests/core --output-dir="${TEMP_DIR}"
 kubectl apply -f "${TEMP_DIR}"

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -8,7 +8,7 @@ function kubectlExpandApply() {
         echo "dir is required as the first parameter!"
     fi
 
-    find "${DIR}" -type f -name "*.yaml" -print0 | xargs -0 -n1 cat | ${GOMPLATE} | kubectl apply -f -
+    find "${DIR}" -type f -name "*.yaml" -print0 | sort -z | xargs -0 -n1 cat | ${GOMPLATE} | kubectl apply -f -
 }
 
 function kubectlExpandDelete() {
@@ -17,6 +17,6 @@ function kubectlExpandDelete() {
         echo "dir is required as the first parameter!"
     fi
 
-    find "${DIR}" -type f -name "*.yaml" -print0 | xargs -0 -n1 cat | ${GOMPLATE} | kubectl delete -f -
+    find "${DIR}" -type f -name "*.yaml" -print0 | sort -z | xargs -0 -n1 cat | ${GOMPLATE} | kubectl delete -f -
 }
 


### PR DESCRIPTION
This change does the following:
- Create the gmp-prombecnh service account during the setup because the core manifests expect them
- Grant the service account approriate permissions for the `core` and `gmp-system` namespaces, and connect it to the appropriate k8s service accounts
- Have the `gmp-system` namepsace service accounts impersonate the `gmp-prombench` service account
- Sort the files in the `kubectlExpandApply` to make sure the resulting combined yaml is valid (previously was invalid sometimes because some files didn't have the `---` delimiter at the start and end)
- Use the gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.7-gke.0 image instead